### PR TITLE
Adding Object.assign polyfill for legacy node support

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "homepage": "https://github.com/onefinancial/npm-fast-sync#readme",
   "dependencies": {
+    "es6-object-assign": "^1.0.1",
     "lodash": "^3.10.1",
     "rimraf": "^2.5.0",
     "rx": "^4.0.7",

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,10 @@ import path from 'path';
 import rimraf from 'rimraf';
 import Rx from 'rx';
 import semver from 'semver';
+import assignPolyfill from 'es6-object-assign';
+
+// polyfill Object.assign for legacy versions of node.
+assignPolyfill.polyfill();
 
 Rx.config.longStackSupport = true;
 


### PR DESCRIPTION
The only thing preventing this package from working in older versions of node is Object.assign support, this pull requests adds a polyfill to add that support.